### PR TITLE
add option to hide verified organization button

### DIFF
--- a/chrome/applyOptions.js
+++ b/chrome/applyOptions.js
@@ -20,6 +20,7 @@ chrome.storage.sync.get(
     noBookmarksButton: false,
     noListsButton: false,
     noDirectMessageButton: false,
+    noVerifiedOrgButton: false,
   },
   function (items) {
     if (items.feedWidth === "700") {
@@ -135,5 +136,12 @@ chrome.storage.sync.get(
         display: none !important;
       }`);
     }
+
+    if (items.noVerifiedOrgButton === true) {
+      addStyles(`a[aria-label="Verified Organizations"] {
+        display: none;
+      }`);
+    }
+
   }
 );

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -607,6 +607,12 @@
         <span>Remove direct message button</span>
       </label>
     </p>
+    <p>
+      <label>
+        <input type="checkbox" id="verified-org" />
+        <span>Remove verified organization button</span>
+      </label>
+    </p>
     <button id="save">Save</button>
   </main>
   <div id="status"></div>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -13,6 +13,7 @@ function save_options() {
   var noBookmarksButton = document.getElementById("bookmarks").checked;
   var noListsButton = document.getElementById("lists").checked;
   var noDirectMessageButton = document.getElementById("direct-message").checked;
+  var noVerifiedOrgButton = document.getElementById("verified-org").checked;
   chrome.storage.sync.set(
     {
       feedWidth: feedWidth,
@@ -28,6 +29,7 @@ function save_options() {
       noBookmarksButton: noBookmarksButton,
       noListsButton: noListsButton,
       noDirectMessageButton: noDirectMessageButton,
+      noVerifiedOrgButton: noVerifiedOrgButton,
     },
     function () {
       // Update status to let user know options were saved.
@@ -58,6 +60,7 @@ function restore_options() {
       noBookmarksButton: false,
       noListsButton: false,
       noDirectMessageButton: false,
+      noVerifiedOrgButton: false,
     },
     function (items) {
       document.getElementById("feed-width").value = items.feedWidth;
@@ -73,6 +76,7 @@ function restore_options() {
       document.getElementById("bookmarks").checked = items.noBookmarksButton;
       document.getElementById("lists").checked = items.noListsButton;
       document.getElementById("direct-message").checked = item.noDirectMessageButton;
+      document.getElementById("verified-org").checked = item.noVerifiedOrgButton;
     }
   );
 }


### PR DESCRIPTION
- [x] adds option interface in chrome extension preferences to hide verified organization button

after:
<img width="1440" alt="CleanShot 2023-04-21 at 16 11 57 2@2x" src="https://user-images.githubusercontent.com/1177031/233756524-6129f239-88ed-42f3-8769-43641fa8cd29.png">

before:
![CleanShot 2023-04-21 at 12 45 50@2x](https://user-images.githubusercontent.com/1177031/233756520-d6273eb4-e820-40d3-9067-ce4fbdc756de.png)


